### PR TITLE
fix: dashboard layout

### DIFF
--- a/src/app/(routes)/dashboard/page.tsx
+++ b/src/app/(routes)/dashboard/page.tsx
@@ -130,10 +130,10 @@ export default function Dashboard() {
             filteredProfiles: user.scannedProfiles,
           }),
         }
-      ).catch((error) => console.log(error));
+      ).catch(error => console.log(error));
       // update progress bar
       const delay = (ms: number) =>
-        new Promise((resolve) => setTimeout(resolve, ms));
+        new Promise(resolve => setTimeout(resolve, ms));
       const delayTime = 2000; // 2 seconds per profile
       for (let i = 0; i < numScannedProfiles; i++) {
         await delay(delayTime);
@@ -193,7 +193,7 @@ export default function Dashboard() {
   }, [user]);
 
   return (
-    <div className="flex flex-col gap-8 py-10">
+    <div className="flex flex-col gap-8 py-10 container">
       {user && (
         <>
           <MonthlyModal
@@ -228,14 +228,17 @@ export default function Dashboard() {
               percentage={percentage}
               removalProgressMessage={removalProgressMessage}
             />
-            <EmailBreachesCard breaches={user.breaches} className="" />
+            <EmailBreachesCard
+              breaches={user.breaches}
+              className=""
+            />
             <RemovalsTableCard
               profiles={[...user.scannedProfiles, ...user.removedProfiles]}
               className="md:col-span-2"
             />
           </div>
           {/* desktop view */}
-          <div className="hidden lg:flex flex-row gap-8">
+          <div className="hidden lg:grid grid-cols-[2fr,1fr] gap-8">
             <div className="flex flex-col gap-8">
               <h1 className="text-[50px] font-medium leading-[55px] tracking-[-2.5px]">
                 {user.firstName !== ""
@@ -243,9 +246,8 @@ export default function Dashboard() {
                   : "Your Dashboard"}
               </h1>
               <ExpandedProfileSearch />
-              <div className="flex flex-row gap-8">
+              <div className="grid grid-cols-2 gap-8">
                 <StatisticsCard
-                  className="w-[50%]"
                   heading="This month"
                   value={
                     user.scannedProfiles.length + user.removedProfiles.length
@@ -272,7 +274,10 @@ export default function Dashboard() {
                 percentage={percentage}
                 removalProgressMessage={removalProgressMessage}
               />
-              <EmailBreachesCard breaches={user.breaches} className="" />
+              <EmailBreachesCard
+                breaches={user.breaches}
+                className=""
+              />
             </div>
           </div>
         </>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,9 +12,9 @@ const config = {
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: "0",
       screens: {
-        "2xl": "1400px",
+        "2xl": "1600px",
       },
     },
     extend: {


### PR DESCRIPTION
Fix the dashboard layout not staying still.

Before:

https://github.com/erazer-security/erazer/assets/28866825/17e88ac1-41d9-4d05-9853-e87109d641d4

After:

https://github.com/erazer-security/erazer/assets/28866825/f226b0f5-6bff-4efe-8416-11d296151425

The issue was in the layout rules that allowed taking as much space as the elements wanted, and the elements wanted to fit their content as much as possible without causing overflow.

There is plenty of empty space, the left-hand side component has some flexibility in its width because it had some rules for its children components to take some of the empty space if it is free. But when the email component is expanded, it now suddenly has bigger content and requires a lot more space. So, the browser gave the free space to the email component, but it was still not enough to show the content without overflow, so it took that free, flexible space from the left-hand side component and gave it to the email component. Now, the left hand side component cannot shrink more, because it will overflow, there is no more empty space, and the email component's new content is just text, so the text will just spill to the next line.

The solution is to make the space distribution logic align with our design. We could, for example, put a max width to the email component, and all the free space left we will redirect to the left hand side component. But if we scale our viewport down, the free space will decrease and thus the left hand side component. Another option is to define proportions - 67% of the whole parent width for the left hand side component, and 33% for the email component. And no matter the width of the page, they will maintain this proportion. The only downside is to handle small devices - but we already do this, that is why I decided to use the latter option. `grid` can achieve this very well.

Lastly, I added the container class to the dashboard page. Currently the content of the page can grow without any limit, and on ultra wide screens this can look too much. 

We usually put this class at the very root of every page and layout components will have restricted max width. But this will always depend on the design, for the landing page, for example, we can't do this.