### PR TITLE
fix: input overflow on safari

### DIFF
--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  semi: true,
+  tabWidth: 2,
+  printWidth: 80,
+  singleQuote: false,
+  trailingComma: "es5",
+  jsxBracketSameLine: false,
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,6 +73,9 @@
   body {
     @apply bg-background text-foreground;
   }
+  input {
+    @apply w-full;
+  }
 }
 
 html {


### PR DESCRIPTION
The fix might seem very brief, but that's how it works:

1. Fix is in adding `width: 100%` to the input. Why 100%? I think this is the most universal and pretty flexible value we could use, but most importantly, we should use our value that will override the default width of the input.
2. If it worked on Chrome but didn't in some other environment, it could be the differences in the environments that caused this issue. You showed iPhone screens, and it uses Safari Mobile as the main browser engine (even if it is the Chrome app, it is Safari Mobile under the hood). One thing you should know is that each browser engine has its own default styles (CSS) for everything, and they differ. Moreover, some functionality is implemented differently in different browsers. Also, Mobile OS browsers also differ from Desktop OS browsers.
3. I started testing different components trying to find one that is causing the whole modal to overflow. If one element is too big, it will cause its parent to be as wide as its children, and the sibling elements will strive to stretch to the parent's width if they have such a rule enabled.
4. When I found the `<input />` component, I realized that it doesn't specify any width. And thus browsers define its width by themselves. I don't know which value they use exactly (but it seems like Chrome does a better job choosing the value), and I don't really need to since we have to override this default behavior because we don't want our inputs to have an arbitrary width chosen by others.
5. Lastly, I added the `prettier.config` file that will help us to work on this project with different IDE settings and still maintain the same coding style.


https://github.com/erazer-security/erazer/assets/28866825/e2944bc2-bbe4-4534-ba50-86700e29fadc

