### PR TITLE
fix: restrict modal max height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "eslint": "^8",
         "eslint-config-next": "14.0.4",
         "postcss": "^8",
-        "tailwindcss": "^3.3.0",
+        "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.0.4",
     "postcss": "^8",
-    "tailwindcss": "^3.3.0",
+    "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 border-[#31343D] border rounded-[30px] backdrop-blur-xl p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] outline-none",
+        "fixed left-[50%] top-[50%] z-50 grid w-[90%] translate-x-[-50%] translate-y-[-50%] gap-4 border-[#31343D] border rounded-[30px] backdrop-blur-xl p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] outline-none max-h-[95svh] overflow-y-auto",
         className
       )}
       {...props}


### PR DESCRIPTION
1. I have updated tailwind to use new dimension units. if you are curious: https://tailwindcss.com/blog/tailwindcss-v3-4 , https://university.webflow.com/lesson/small-large-and-dynamic-viewport-units#best-practices
2. There are 2 ways to solve this issue, first is to restrict the modal max height to not grow beyond device's height, and make the content scrollable, or make the whole page scrollable when the modal's height is too big. The second solution seems much harder and may be even not that beautiful (and I rarely used such Dialogs), so I chose the first solution. But it is still a viable option, and if you disagree, we can discuss the pros and cons and create a task for later and use this fix for now

https://github.com/erazer-security/erazer/assets/28866825/47f4a808-3eb7-4142-b391-ab1685d5ff64


On desktop it is still the same:
<img width="1728" alt="Screenshot 2024-03-19 at 1 12 50 AM" src="https://github.com/erazer-security/erazer/assets/28866825/6b4f9701-f62b-4748-995f-93dd0bf8242c">
