### PR TITLE
feat: resize Globe

### DIFF
--- a/src/app/_components/expandedProfileSearch/index.tsx
+++ b/src/app/_components/expandedProfileSearch/index.tsx
@@ -202,9 +202,11 @@ export default function ExpandedProfileSearch({
       />
       <Dialog open={openDialog}>
         {loading ? (
-          <DialogContent className="justify-center px-20 py-14 outline-none">
+          <DialogContent className="justify-center px-10 py-14 outline-none">
             <DialogHeader className="gap-5">
-              <DialogTitle className="text-center">{heading}</DialogTitle>
+              <DialogTitle className="text-center text-pretty">
+                {heading}
+              </DialogTitle>
               <Progress value={progress} className="h-[3px]" />
             </DialogHeader>
             <Globe />

--- a/src/app/_components/globe/index.tsx
+++ b/src/app/_components/globe/index.tsx
@@ -1,16 +1,37 @@
-import React from "react";
+import React, { useState } from "react";
 import createGlobe from "cobe";
 import { useEffect, useRef } from "react";
 
+const maxWidth = 600;
+
 export default function Globe() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<any>();
+  const [size, setSize] = useState(maxWidth);
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.contentBoxSize) {
+          setSize(Math.min(entry.contentBoxSize[0].inlineSize, maxWidth));
+        }
+      }
+    });
+
+    if (containerRef.current) resizeObserver.observe(containerRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
   useEffect(() => {
     let phi = 0;
 
     const globe = createGlobe(canvasRef.current, {
       devicePixelRatio: 2,
-      width: 600 * 2,
-      height: 600 * 2,
+      width: size * 2,
+      height: size * 2,
       phi: 0,
       theta: 0,
       dark: 1,
@@ -22,6 +43,7 @@ export default function Globe() {
         0.49411764705882355, 0.18823529411764706, 0.8823529411764706,
       ],
       glowColor: [1, 1, 1],
+      offset: [0, 0],
       markers: [
         // longitude latitude
         { location: [37.7595, -122.4367], size: 0.05 },
@@ -48,14 +70,21 @@ export default function Globe() {
     return () => {
       globe.destroy();
     };
-  }, []);
+  }, [size]);
 
   return (
-    <>
+    <div
+      ref={containerRef}
+      style={{
+        maxWidth: `${maxWidth}px`,
+      }}
+    >
       <canvas
         ref={canvasRef}
-        className="w-[600px] h-[600px] max-w-full aspect-square"
+        width={size * 2}
+        height={size * 2}
+        className="w-full aspect-square"
       />
-    </>
+    </div>
   );
 }

--- a/src/app/_components/profileSearch/index.tsx
+++ b/src/app/_components/profileSearch/index.tsx
@@ -288,9 +288,11 @@ export default function ProfileSearch() {
       />
       <Dialog open={openDialog}>
         {loading ? (
-          <DialogContent className="justify-center px-20 py-14 outline-none">
+          <DialogContent className="justify-center px-10 py-14 outline-none">
             <DialogHeader className="gap-5">
-              <DialogTitle className="text-center">{heading}</DialogTitle>
+              <DialogTitle className="text-center text-pretty">
+                {heading}
+              </DialogTitle>
               <Progress value={progress} className="h-[3px]" />
             </DialogHeader>
             <Globe />


### PR DESCRIPTION
I couldn't find CSS only solution, it seems like JS is required here. To calculate the width of an element, even if the user resizes the window, you should use `ResizeObserver`.

I also reduced padding on mobile screens. `text-pretty` will strive to strike a balance when text wraps onto the next line - https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap


https://github.com/erazer-security/erazer/assets/28866825/c39c9a33-7594-4c16-9d45-5dc18ba608a5


