### PR TITLE
feat: mobile results overview table

### DIFF
--- a/src/app/_components/removalsTableCard/index.tsx
+++ b/src/app/_components/removalsTableCard/index.tsx
@@ -168,9 +168,9 @@ const ProfileCell = ({ profile, ...tableCellProps }: ProfileCellProps) => {
 const WebsiteCell = ({ profile }: ProfileCellProps) => {
   return (
     <TableCell>
-      <div className="flex flex-row items-center gap-1">
+      <div className="flex items-center gap-1">
         {profile.website}{" "}
-        <div className="hidden md:block">
+        <div className="hidden md:block shrink-0">
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger>
@@ -187,7 +187,7 @@ const WebsiteCell = ({ profile }: ProfileCellProps) => {
             </Tooltip>
           </TooltipProvider>
         </div>
-        <div className="block md:hidden">
+        <div className="block md:hidden shrink-0">
           <Popover>
             <PopoverTrigger>
               <Image

--- a/src/app/_components/removalsTableCard/index.tsx
+++ b/src/app/_components/removalsTableCard/index.tsx
@@ -103,7 +103,7 @@ export default function RemovalsTableCard({
                       className="hidden md:table-cell"
                     />
                   </TableRow>
-                  <TableRow className="border-none md:hidden">
+                  <TableRow className="border-none md:hidden transition-colors hover:bg-[#23242A]">
                     <ProfileCell
                       profile={profile}
                       colSpan={2}

--- a/src/app/_components/removalsTableCard/index.tsx
+++ b/src/app/_components/removalsTableCard/index.tsx
@@ -67,113 +67,50 @@ export default function RemovalsTableCard({
                   Removal Status
                 </TableHead>
                 <TableHead className="text-[#FFFFFF66]">Source</TableHead>
-                <TableHead className="text-[#FFFFFF66]">
+                <TableHead className="text-[#FFFFFF66] hidden md:table-cell">
                   Personal Information
                 </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {profiles.map((profile: Profile, index: number) => (
-                <TableRow
-                  key={index}
-                  className="border-none transition-colors hover:bg-[#23242A]"
-                >
-                  <TableCell>
-                    <div
-                      className={`flex flex-row items-center ${
-                        profile.status === "Pending"
-                          ? "text-[#EFE3FF]"
-                          : "text-[#43BEBE]"
-                      }`}
-                    >
-                      <Image
-                        src={
+                <React.Fragment key={index}>
+                  <TableRow className="border-none transition-colors hover:bg-[#23242A]">
+                    <TableCell>
+                      <div
+                        className={`flex flex-row items-center ${
                           profile.status === "Pending"
-                            ? "/removalsTableCard/pendingDot.svg"
-                            : "/removalsTableCard/removedDot.svg"
-                        }
-                        alt="dot"
-                        width={16}
-                        height={16}
-                      />
-                      {profile.status}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex flex-row items-center gap-1">
-                      {profile.website}{" "}
-                      <div className="hidden md:block">
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <Image
-                                src="/removalsTableCard/tooltip.svg"
-                                alt="Tooltip"
-                                width={16}
-                                height={16}
-                              />
-                            </TooltipTrigger>
-                            <TooltipContent className="w-[350px]">
-                              {whoisDatabrokers[profile.website]}
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
+                            ? "text-[#EFE3FF]"
+                            : "text-[#43BEBE]"
+                        }`}
+                      >
+                        <Image
+                          src={
+                            profile.status === "Pending"
+                              ? "/removalsTableCard/pendingDot.svg"
+                              : "/removalsTableCard/removedDot.svg"
+                          }
+                          alt="dot"
+                          width={16}
+                          height={16}
+                        />
+                        {profile.status}
                       </div>
-                      <div className="block md:hidden">
-                        <Popover>
-                          <PopoverTrigger>
-                            <Image
-                              src="/removalsTableCard/tooltip.svg"
-                              alt="Tooltip"
-                              width={16}
-                              height={16}
-                            />
-                          </PopoverTrigger>
-                          <PopoverContent className="w-[350px]">
-                            {whoisDatabrokers[profile.website]}
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <div className="">
-                      {profile.profile.slice(0, 75)}...{" "}
-                      <div className="hidden md:block">
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger>
-                              <Image
-                                src="/removalsTableCard/tooltip.svg"
-                                alt="Tooltip"
-                                width={16}
-                                height={16}
-                              />
-                            </TooltipTrigger>
-                            <TooltipContent className="w-[350px]">
-                              {profile.profile}
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      </div>
-                      <div className="block md:hidden">
-                        <Popover>
-                          <PopoverTrigger>
-                            <Image
-                              src="/removalsTableCard/tooltip.svg"
-                              alt="Tooltip"
-                              width={16}
-                              height={16}
-                            />
-                          </PopoverTrigger>
-                          <PopoverContent className="w-[350px]">
-                            {profile.profile}
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    </div>
-                  </TableCell>
-                </TableRow>
+                    </TableCell>
+                    <WebsiteCell profile={profile} />
+                    <ProfileCell
+                      profile={profile}
+                      className="hidden md:table-cell"
+                    />
+                  </TableRow>
+                  <TableRow className="border-none md:hidden">
+                    <ProfileCell
+                      profile={profile}
+                      colSpan={2}
+                      className="pt-0"
+                    />
+                  </TableRow>
+                </React.Fragment>
               ))}
             </TableBody>
           </Table>
@@ -183,3 +120,89 @@ export default function RemovalsTableCard({
     </div>
   );
 }
+
+type ProfileCellProps = React.TdHTMLAttributes<HTMLTableCellElement> & {
+  profile: Profile;
+};
+
+const ProfileCell = ({ profile, ...tableCellProps }: ProfileCellProps) => {
+  return (
+    <TableCell {...tableCellProps}>
+      {profile.profile.slice(0, 75)}...{" "}
+      <div className="hidden md:block">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <Image
+                src="/removalsTableCard/tooltip.svg"
+                alt="Tooltip"
+                width={16}
+                height={16}
+              />
+            </TooltipTrigger>
+            <TooltipContent className="w-[350px]">
+              {profile.profile}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <div className="block md:hidden">
+        <Popover>
+          <PopoverTrigger>
+            <Image
+              src="/removalsTableCard/tooltip.svg"
+              alt="Tooltip"
+              width={16}
+              height={16}
+            />
+          </PopoverTrigger>
+          <PopoverContent className="w-[350px]">
+            {profile.profile}
+          </PopoverContent>
+        </Popover>
+      </div>
+    </TableCell>
+  );
+};
+
+const WebsiteCell = ({ profile }: ProfileCellProps) => {
+  return (
+    <TableCell>
+      <div className="flex flex-row items-center gap-1">
+        {profile.website}{" "}
+        <div className="hidden md:block">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <Image
+                  src="/removalsTableCard/tooltip.svg"
+                  alt="Tooltip"
+                  width={16}
+                  height={16}
+                />
+              </TooltipTrigger>
+              <TooltipContent className="w-[350px]">
+                {whoisDatabrokers[profile.website]}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        <div className="block md:hidden">
+          <Popover>
+            <PopoverTrigger>
+              <Image
+                src="/removalsTableCard/tooltip.svg"
+                alt="Tooltip"
+                width={16}
+                height={16}
+              />
+            </PopoverTrigger>
+            <PopoverContent className="w-[350px]">
+              {whoisDatabrokers[profile.website]}
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+    </TableCell>
+  );
+};


### PR DESCRIPTION
The solution:

I couldn't make the single row 2D, so I made the second row, shown on mobile and hidden on desktop. The mobile second row will have only one cell - for profile info - and will have `colSpan={2}` to span two columns.

The third column is hidden on mobile.

Ideally, we should reduce the practice of making mobile and desktop versions of the same thing and hide one when the other is shown with CSS. Because we are duplicating the code - and users will download both versions, one of them will just be hidden. However, if the desktop and mobile versions differ substantially, this is the tradeoff we can make. And I think this second row is one such case.



https://github.com/erazer-security/erazer/assets/28866825/24e9a670-016a-47bd-890d-fe0dbb761a4e

