### PR TITLE
feat: loop testimonials carousel

### DIFF
--- a/src/app/_components/testimonialsCarousel/index.tsx
+++ b/src/app/_components/testimonialsCarousel/index.tsx
@@ -12,11 +12,16 @@ import testimonials from "./testimonials.json";
 export default function TestimonialsCarousel() {
   return (
     <div className="overflow-x-hidden">
-      <Carousel>
-        <CarouselContent className="w-[525px] h-[360px]">
+      <Carousel
+        opts={{
+          loop: true,
+          align: "start",
+        }}
+      >
+        <CarouselContent>
           {testimonials.testimonials.map(
             (testimonial: Testimonial, index: number) => (
-              <CarouselItem key={index}>
+              <CarouselItem key={index} className="basis-[525px] h-[360px]">
                 <div className="bg-[#ffffff0d] h-full flex flex-col gap-4 rounded-3xl p-12">
                   <Image
                     src={


### PR DESCRIPTION
the task:
https://www.notion.so/Make-Testimonials-infinite-scroll-7d5265e5f9fb46df8daa789c2a4d19b6?pvs=4

Solution:
According to the docs, the slide sizing should happen on Slide component - https://www.embla-carousel.com/guides/slide-sizes/ (here the width is important). However, our code sized the Container component, which actually broke the Carousel, even if it didn't look like it was broken. That is why the loop was not working. However, after fixing the slide size, the loop started working. I also made the alignment start from the leftmost slide, otherwise it would show starting from the central slide.


https://github.com/erazer-security/erazer/assets/28866825/dc25cbd7-136c-43c9-ad4f-b52159226e4c

