### PR TITLE
feat: use Popover for cities dropdown

### DIFF
--- a/src/app/_components/profileSearch/tooManyProfiles.tsx
+++ b/src/app/_components/profileSearch/tooManyProfiles.tsx
@@ -47,38 +47,37 @@ export default function TooManyProfiles({
             Search
           </button>
         </Popover.Anchor>
-        <Popover.Portal>
-          <Popover.Content
-            className="z-[51]"
-            align="start"
-            sideOffset={8}
-            onOpenAutoFocus={(event) => {
-              // Prevent the input from losing focus when the popover opens
-              // @see https://www.radix-ui.com/primitives/docs/components/popover#content
-              event.preventDefault();
-            }}
-          >
-            {showSuggestedLocations && (
-              <ul className="w-fit border border-[#31343D] rounded-3xl bg-[#16171F] p-5 top-16 left-0 empty:hidden">
-                {locations
-                  .filter((location: string) => location.includes(userCity))
-                  .slice(0, 10)
-                  .map((location: string, index: number) => (
-                    <li
-                      key={index}
-                      className="text-left rounded-[4px] hover:bg-slate-400 hover:cursor-pointer"
-                      onClick={() => {
-                        setUserCity(location);
-                        setShowSuggestedLocations(false);
-                      }}
-                    >
-                      {location}
-                    </li>
-                  ))}
-              </ul>
-            )}
-          </Popover.Content>
-        </Popover.Portal>
+
+        <Popover.Content
+          className="z-[1]"
+          align="start"
+          sideOffset={8}
+          onOpenAutoFocus={(event) => {
+            // Prevent the input from losing focus when the popover opens
+            // @see https://www.radix-ui.com/primitives/docs/components/popover#content
+            event.preventDefault();
+          }}
+        >
+          {showSuggestedLocations && (
+            <ul className="w-fit border border-[#31343D] rounded-3xl bg-[#16171F] p-5 top-16 left-0 empty:hidden">
+              {locations
+                .filter((location: string) => location.includes(userCity))
+                .slice(0, 10)
+                .map((location: string, index: number) => (
+                  <li
+                    key={index}
+                    className="text-left rounded-[4px] hover:bg-slate-400 hover:cursor-pointer"
+                    onClick={() => {
+                      setUserCity(location);
+                      setShowSuggestedLocations(false);
+                    }}
+                  >
+                    {location}
+                  </li>
+                ))}
+            </ul>
+          )}
+        </Popover.Content>
       </Popover.Root>
     </div>
   );

--- a/src/app/_components/profileSearch/tooManyProfiles.tsx
+++ b/src/app/_components/profileSearch/tooManyProfiles.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import * as Popover from "@radix-ui/react-popover";
+
 interface TooManyProfilesProps {
   userCity: string;
   setUserCity: (userCity: string) => void;
@@ -23,42 +25,61 @@ export default function TooManyProfiles({
         provide your city to narrow down the results. Or you can simply just go
         through all of them.
       </p>
-      <div className="relative z-50 w-fit flex flex-row justify-between gap-5 p-2 rounded-[40px] border-[1px] border-solid border-[#31343D] backdrop-blur-xl">
-        <input
-          autoComplete="off"
-          type="text"
-          placeholder="City"
-          value={userCity}
-          onChange={(event) => setUserCity(event.target.value.toUpperCase())}
-          onClick={() => setShowSuggestedLocations(true)}
-          className="text-white placeholder:text-white text-base font-normal bg-transparent outline-none"
-        />
-        <button
-          onClick={narrowProfiles}
-          className="flex justify-center items-center px-4 py-2 rounded-full bg-gradient-to-br from-[#7E30E1] to-[#49108B] hover:from-[#3F0687] hover:to-[#36096A] active:from-[#100320] active:to-[#310267] transition-colors duration-100 ease-in-out"
-        >
-          Search
-        </button>
-        {showSuggestedLocations && (
-          <ul className="absolute w-fit border border-[#31343D] rounded-3xl bg-[#16171F] p-5 top-16 left-0 empty:hidden">
-            {locations
-              .filter((location: string) => location.includes(userCity))
-              .slice(0, 10)
-              .map((location: string, index: number) => (
-                <li
-                  key={index}
-                  className="text-left rounded-[4px] hover:bg-slate-400 hover:cursor-pointer"
-                  onClick={() => {
-                    setUserCity(location);
-                    setShowSuggestedLocations(false);
-                  }}
-                >
-                  {location}
-                </li>
-              ))}
-          </ul>
-        )}
-      </div>
+      <Popover.Root>
+        <Popover.Anchor className="w-full md:max-w-80 flex flex-row justify-between gap-5 p-2 rounded-[40px] border-[1px] border-solid border-[#31343D] backdrop-blur-xl">
+          <Popover.Trigger asChild>
+            <input
+              autoComplete="off"
+              type="text"
+              placeholder="City"
+              value={userCity}
+              onChange={(event) =>
+                setUserCity(event.target.value.toUpperCase())
+              }
+              onClick={() => setShowSuggestedLocations(true)}
+              className="text-white placeholder:text-white text-base font-normal bg-transparent outline-none"
+            />
+          </Popover.Trigger>
+          <button
+            onClick={narrowProfiles}
+            className="flex justify-center items-center px-4 py-2 rounded-full bg-gradient-to-br from-[#7E30E1] to-[#49108B] hover:from-[#3F0687] hover:to-[#36096A] active:from-[#100320] active:to-[#310267] transition-colors duration-100 ease-in-out"
+          >
+            Search
+          </button>
+        </Popover.Anchor>
+        <Popover.Portal>
+          <Popover.Content
+            className="z-[51]"
+            align="start"
+            sideOffset={8}
+            onOpenAutoFocus={(event) => {
+              // Prevent the input from losing focus when the popover opens
+              // @see https://www.radix-ui.com/primitives/docs/components/popover#content
+              event.preventDefault();
+            }}
+          >
+            {showSuggestedLocations && (
+              <ul className="w-fit border border-[#31343D] rounded-3xl bg-[#16171F] p-5 top-16 left-0 empty:hidden">
+                {locations
+                  .filter((location: string) => location.includes(userCity))
+                  .slice(0, 10)
+                  .map((location: string, index: number) => (
+                    <li
+                      key={index}
+                      className="text-left rounded-[4px] hover:bg-slate-400 hover:cursor-pointer"
+                      onClick={() => {
+                        setUserCity(location);
+                        setShowSuggestedLocations(false);
+                      }}
+                    >
+                      {location}
+                    </li>
+                  ))}
+              </ul>
+            )}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
     </div>
   );
 }


### PR DESCRIPTION
Clicking outside didn't close the cities list because we didn't implement such a feature. We could do it ourselves, but since we already use Radix (as a part of shadcn), I decided to use the popover component that handles this for us (and many other features and logic)

1. Ancor is the component to align the dropdown (Content) to.
2. The Content component needs z-1 because the following Carousel component has a `relative` position, and a non-default positioned element creates a new stacking context, which means it is competing for z value with other non-default positioned elements, like our Content (which is most probably `absolute`). They both have z-index values unset, therefore the component that goes on top is the one that is defined later in HTML - Carousel component. Specifying any positive z-index for the Content dropdown will put it above the Carousel.


This PR will most probably cause a conflict with another, so we should merge one, then fix another and merge it afterwards


https://github.com/erazer-security/erazer/assets/28866825/e5a68c57-fec0-4f08-aea4-4def50348dae

