### PR TITLE
fix scroll when navigating

### DIFF
--- a/src/app/_components/cybersecurityStatistics/index.tsx
+++ b/src/app/_components/cybersecurityStatistics/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function CybersecurityStatistics() {
   return (
-    <div>
+    <div className="pb-16 lg:pb-28">
       <h2 className="text-[50px] md:text-[56px] text-center font-medium leading-[55px] tracking-tighter mt-32 lg:mt-36 mb-7">
         Cybersecurity by the numbers
       </h2>

--- a/src/app/_components/header/index.tsx
+++ b/src/app/_components/header/index.tsx
@@ -52,17 +52,20 @@ export default function Header({ className }: HeaderProps) {
 
   // Check if page user scrolled 75px (roughly the height of header) to update the background color of the header
   useEffect(() => {
-    if (typeof window != "undefined") {
-      const changeColor = () => {
-        if (window.scrollY >= 75) {
-          setTransparent(true);
-        } else {
-          setTransparent(false);
-        }
-      };
-      window.addEventListener("scroll", changeColor);
-    }
-  });
+    const changeColor = () => {
+      if (window.scrollY >= 75) {
+        setTransparent(true);
+      } else {
+        setTransparent(false);
+      }
+    };
+
+    window.addEventListener("scroll", changeColor);
+
+    return () => {
+      window.removeEventListener("scroll", changeColor);
+    };
+  }, []);
 
   const HeaderRoutes: string[] = ["The Process", "About Us", "Pricing"];
   return (

--- a/src/app/_components/process/index.tsx
+++ b/src/app/_components/process/index.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 export default function Process() {
   return (
-    <div className="mt-32 lg:mt-56">
+    <div className="pt-16 lg:pt-28">
       <h1 className="text-center text-[50px] md:text-[77px] font-medium leading-10 tracking-tighter">
         The Process
       </h1>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className="scroll-pt-20">
       <GoogleAnalytics gaId="G-GHPRYNE6WR" />
       <Script id="hotjar">
         {`(function (h, o, t, j, a, r) {


### PR DESCRIPTION
This one is tricky as well. The solution seems to be working.

The next.js itself handles the scrolling. It could be a bug described here: https://github.com/vercel/next.js/issues/45187
. But it can also be the sticky header that we should account for when scrolling. Because it is removed from the normal flow of the document, the nextjs might not include it in the calculation of the scroll position. So I started googling how to scroll when you have a sticky header and found this very interesting CSS property I never heard of before. (https://stackoverflow.com/a/67324390) And it worked! 


https://github.com/erazer-security/erazer/assets/28866825/f6d5dc1a-89b3-4d89-b05f-aa5a618dac99

After I added scroll-padding I had to make one adjustments - the Processes block was pushed way below, so I removed its top margin and split it with a component above. This way the start of Processes block is aligned with the header height.

There are several nuances with useEffect:
1. It can take 1 or 2 arguments, the first is callback, and the second is a dependency list. When you don't prodive a dependency list, the callback will run on every rerender. And there are tons of things that can cause a component to rerender - a state update, a prop update or if any of those happen with any parent component.
2. If we pass an empty array as a dep. list, it means that the callback will run exactly once - when the component first rendered. The component renders for the first time after mounting (i.e. the component appears on a screen, it didn't exist before).
3. the useEffect is always run on the browser, so it has `window` defined, and no need to check for that
4. When you add an event listener, you should remove it when you no longer need it. Otherwise, you will leave them hanging in the browser's memory. In react, we no longer need it when we unmount a component. The return function of useEffect runs right before the component unmounts. This return function is created so that developers can do any cleanups they should do. If the component is remounting, we remove the old event listener before unmounting and then the component is mounted again, and rendered, and we run the useEffect and create a brand new event listener. Even if we swap them constantly, we still have only one active.
5. The fact that you had your useEffect run on every rerender, which can happen 20 times in 5 sec, and you didn't clean up the event listeners, meant that you had 20 active event listeners all listening for window scrolling and toggling the transparency flag. 
<img width="547" alt="image" src="https://github.com/erazer-security/erazer/assets/28866825/6c6d4048-3595-4f1c-b161-365cd1ab47f1">

By the way, if you are curious, you can read about useEffect here - https://react.dev/learn/synchronizing-with-effects

React's official documentation is perhaps the best source to learn react from